### PR TITLE
Field,Stamp,Instanceクラスの書き換え（Python　→　C#）

### DIFF
--- a/procon_stamp/model/Field.cs
+++ b/procon_stamp/model/Field.cs
@@ -3,8 +3,168 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using procon_stamp.model;
 
 namespace procon_stamp.model {
     class Field {
+
+        // お手本のフィールド情報を二次元配列で格納するリスト。
+        private static int[][] target_field;
+
+        // お手本のフィールドのx,y軸方向サイズ。
+        public static int field_x_size;
+        public static int field_y_size;
+
+        // お手本の黒い箇所の座標を格納するリスト。
+        public static List<Tuple<int, int>> black_cell_list_of_target_field;
+
+        // 分割したお手本のフィールド情報（座標）を格納するリスト。
+        public static List<Tuple<int, int>> divide_list;
+        
+        // 分割したお手本のフィールド情報（値[0,1]）を格納するリスト。
+        public static List<Tuple<int, int>> divide_value_list;
+        
+        // 分割したお手本のフィールドごとの合計した値[0,1]を格納するリスト。
+        public static List<Tuple<int, int>> divide_total_value_list;
+      
+        // ランダムの対象となる分割フィールドのインデックスを格納するリスト。 
+        public static List<Tuple<int, int>> random_target_field;
+    
+        // 自分のフィールド情報を二次元配列で格納するリスト。
+        private List<List<int>> my_field;
+
+        // お手本情報を二次元配列で格納するリスト。
+        public static List<List<int>> target_field;
+
+        /// <summary>
+        /// 引数なしコンストラクタ
+        /// </summary>
+        public Field()
+        {
+            for(int i = 0; i < Field.field_y_size; i++)
+            {
+                for (int j = 0; j < Field.field_x_size; j++)
+                {
+                    this.my_field[i][j] = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// クラス変数（target_field、field_x_size、field_y_size）をセットする
+        /// </summary>
+        /// <param name="target_field_information">お手本情報</param>
+        public static void SetTargetField(string target_field_information)
+        {
+            string target_field_str;
+            string[] target_field_information_for_split = target_field_information.Split(';');
+            this.field_x_size = int.Parse(target_field_information_for_split[0]);
+            this.field_y_size = int.Parse(target_field_information_for_split[1]);
+            target_field_str = target_field_information_for_split[2];
+             
+            // target_fieldを作成する
+            int current_position = 0;
+            for(int y = 0; y < this.field_y_size; y++)
+            {
+                for(int x = 0; x < this.field_x_size; x++)
+                {
+                    this.target_field[y][x] = int.Parse(target_field_str[current_position]);
+                    current_position += 1;
+                }
+            }
+        }
+
+        /// <summary>
+        /// target_fieldとmy_fieldとの一致数を計算する。
+        /// </summary>
+        /// <returns>一致数</returns>
+        public int NumOfMatchesWithTargetField()
+        {
+            int match_count = 0;
+            for (int i = 0; i < Field.field_y_size ; i++)
+            {
+                if (Field.target_field[i] == this.my_field[i])
+                {
+                    match_count += Field.field_x_size;
+                    continue;
+                }
+                else
+                {
+                    for (int j = 0; j < field_x_size; j++)
+                    {
+                        if(Field.target_field[i][j] == this.myField[i][j])
+                        {
+                            match_count += 1;
+                        }
+
+                    }
+                }
+            }
+            return match_count;
+        }
+
+        /// <summary>
+        /// お手本の黒い箇所の座標を格納するリスト
+        /// </summary>
+        /// <returns></returns>
+        public List<Tuple<int, int>> GetBlackCellCoordinateForTargetField()
+        {
+            if (Field.black_cell_list_of_target_field)
+            {
+                return Field.black_cell_list_of_target_field;
+            }
+            else
+            {
+                for(int y = 0; y < Field.field_y_size; y++)
+                {
+                    for (int x = 0; x < Field.field_x_size; x++)
+                    {
+                        if(Field.target_field[y][x] == 1)
+                        {
+                            Field.black_cell_list_of_target_field.Add(new Tuple<int, int>(y, x));
+                        }
+                    }
+                }
+                
+            }
+            return Field.black_cell_list_of_target_field;
+        }
+        
+
+        /// <summary>
+        /// my_fieldにスタンプを押す。
+        /// </summary>
+        /// <param name=""></param>
+        public void PressStamp(Stamp stamp_object, int parallel_translation_x, int parallel_translation_y)
+        {
+            int candidate_press_x = 0;
+            int candidate_press_y = 0;
+
+            List<Tuple<int, int>> press_black_cell_coordinate_list = stamp_object.GetBlackCellCoordinate();
+
+            foreach(Tuple<int, int> press_tuple in press_black_cell_coordinate_list)
+            {
+                candidate_press_x = press_tuple[1] + parallel_translation_x;
+                candidate_press_y = press_tuple[0] + parallel_translation_y;
+            
+                if(candidate_press_x < 0 || candidate_press_y < 0 || candidate_press_x >= Field.field_x_size || candidate_press_y >= Field.field_y_size)
+                {
+                    continue;
+                }
+
+                if(this.my_field[candidate_press_y][candidate_press_x] == 0)
+                {
+                    this.my_field[candidate_press_y][candidate_press_x] = 1;
+                }
+                else if (this.my_field[candidate_press_y][candidate_press_x] == 1)
+                {
+                    this.my_field[candidate_press_y][candidate_press_x] = 0;
+                }
+                else
+                {
+                    Console.WriteLine("pass");
+                }
+            }
+        }
     }
 }

--- a/procon_stamp/model/Instance.cs
+++ b/procon_stamp/model/Instance.cs
@@ -6,5 +6,36 @@ using System.Threading.Tasks;
 
 namespace procon_stamp.model {
     class Instance {
+
+        private List<Tuple<int, int, int>> origin_stamp_object_list;
+        private List<Tuple<int, int, int>> combined_stamp_object_list;
+
+        /// <summary>
+        /// 引数のStampクラスのオブジェクトをstamp_object_listにセットする。
+        /// </summary>
+        /// <param name="stamp_object">スタンプクラスのオブジェクト</param>
+        public void SetOriginStampObject(List<Tuple<int, int, int>> stamp_object)
+        {
+            this.origin_stamp_object_list = new List<Tuple<int, int, int>>(stamp_object);
+        }
+
+        /// <summary>
+        /// できるだけ面積の小さい combined stamp を構築する。
+        /// </summary>
+        public void MakeCombinedStampList()
+        {
+            this.combined_stamp_object_list = new List<Tuple<int, int, int>>(this.origin_stamp_object_list);
+        }
+
+
+        /// <summary>
+        /// 
+        /// 
+        /// </summary>
+        /// <returns>combined stamp</returns>
+        public List<Tuple<int, int, int>> GetCombinedStampObjectList()
+        {
+            return this.combined_stamp_object_list;
+        }
     }
 }

--- a/procon_stamp/model/Stamp.cs
+++ b/procon_stamp/model/Stamp.cs
@@ -6,5 +6,78 @@ using System.Threading.Tasks;
 
 namespace procon_stamp.model {
     class Stamp {
+
+        public int stamp_x_size
+        {
+            get;
+        }
+
+        // スタンプのx、y軸方向サイズ。
+        // private int stamp_x_size;
+        private int stamp_y_size;
+
+        // スタンプの絵の定義。
+        private string definition_of_stamp_picture;
+
+        // スタンプの黒いセルの座標を格納する配列。
+        private List<Tuple<int, int>> black_cell_coordinate_list;
+
+        // スタンプを構成するオリジナルスタンプの情報を保持する3-tupeの配列。
+        // 3-tupleのレイアウトは(index, x軸方向への平行移動距離, y軸方向の平行移動距離)。
+        private List<Tuple<int, int, int>> indices;
+
+        // スタンプのオブジェクトを格納するリスト
+        private List<Tuple<int, int, int>> origin_stamp_list;
+
+
+        /// <summary>
+        /// 引数ありコンストラクタ
+        /// </summary>
+        /// <param name="idx">スタンプのインデックス</param>
+        /// <param name="input_str">スタンプの定義（x軸方向サイズ；y 軸方向サイズ；絵の定義）</param>
+        public Stamp(int idx, string input_str)
+        {
+
+            this.origin_stamp_list.Add(new Tuple<int, int, int>(idx, 0, 0));
+            string[] input_stamp_information = input_str.Split(';');
+            this.stamp_x_size = int.Parse(input_stamp_information[0]);
+            this.stamp_y_size = int.Parse(input_stamp_information[1]);
+            this.definition_of_stamp_picture = input_stamp_information[2];
+
+            // black_cell_coordinate_listの計算
+            int current_position = 0;
+            for (int y = 0; y < stamp_y_size; y++)
+            {
+                for (int x = 0; x < stamp_x_size; x++)
+                {
+                    if (definition_of_stamp_picture[current_position] == '1')
+                    {
+                        this.black_cell_coordinate_list.Add(new Tuple<int, int>(y, x));
+                    }
+                    current_position++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// 
+        /// </summary>
+        /// <returns>フィールドの黒いセルの座標リスト</returns>
+        public List<Tuple<int, int>> GetBlackCellCoordinate()
+        {
+            return this.black_cell_coordinate_list;
+        }
+
+        /// <summary>
+        /// 
+        /// 
+        /// </summary>
+        /// <returns>スタンプクラスのオブジェクトリスト</returns>
+        public List<Tuple<int,int,int>> GetOriginStampList()
+        {
+            return this.origin_stamp_list;
+        }
+
     }
 }


### PR DESCRIPTION
Fieldクラスにおいて、以下2つのメソッドの未実装。
※今回は、RandomSolverが動くところまでがゴールのため
・press_stamp_using_greedy
・devide_field
